### PR TITLE
Update yaml import

### DIFF
--- a/api/director_deployments.go
+++ b/api/director_deployments.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"time"
 
-	"launchpad.net/goyaml"
+	goyaml "gopkg.in/yaml.v2"
 
 	"github.com/cloudfoundry-community/gogobosh/models"
 	"github.com/cloudfoundry-community/gogobosh/net"

--- a/local/director.go
+++ b/local/director.go
@@ -6,7 +6,7 @@ import (
 	"os/user"
 	"path/filepath"
 
-	"launchpad.net/goyaml"
+	goyaml "gopkg.in/yaml.v2"
 )
 
 // BoshConfig describes a local ~/.bosh_config file

--- a/net/http_client.go
+++ b/net/http_client.go
@@ -41,6 +41,9 @@ func PrepareRedirect(req *http.Request, via []*http.Request) error {
 	req.Header.Set("Content-Type", prevReq.Header.Get("Content-Type"))
 	req.Header.Set("User-Agent", prevReq.Header.Get("User-Agent"))
 
+	// For some reason, BOSH rejects (403) redirects with a Referer header
+	req.Header.Del("Referer")
+
 	dumpRequest(req)
 
 	return nil


### PR DESCRIPTION
Updated imports to use the new location to goyaml (failed travis build).  Includes earlier change below:

BOSH rejects redirects that include a Referer header. This fixes the symptom, not the cause.

When I invoke FetchVMsStatus using gogobosh, it calls `GET /deployments/cf-warden/vms?format=full`, which returns a redirect to /tasks/NNN. gogobosh follows this redirect and includes a Referer header. If this header is included, bosh returns a 403 (forbidden).

See [https://lists.cloudfoundry.org/archives/list/cf-bosh@lists.cloudfoundry.org/thread/5WZY5F3457C4VIVSJULFLGLAAYJ2HQ77/](https://lists.cloudfoundry.org/archives/list/cf-bosh@lists.cloudfoundry.org/thread/5WZY5F3457C4VIVSJULFLGLAAYJ2HQ77/)
