### PR TITLE
add ability to refresh uaa auth if refresh token has expired

### DIFF
--- a/bosh_test.go
+++ b/bosh_test.go
@@ -101,12 +101,19 @@ func FakeUAAServer() *httptest.Server {
 	r := martini.NewRouter()
 	count := 1
 	r.Post("/oauth/token", func(r render.Render) {
-		r.JSON(200, map[string]interface{}{
-			"token_type":    "bearer",
-			"access_token":  "foobar" + strconv.Itoa(count),
-			"refresh_token": "barfoo",
-			"expires_in":    3,
-		})
+		if count == 3 {
+			r.JSON(401, map[string]interface{}{
+				"error":             "invalid_token",
+				"error_description": "Invalid refresh token (expired)",
+			})
+		} else {
+			r.JSON(200, map[string]interface{}{
+				"token_type":    "bearer",
+				"access_token":  "foobar" + strconv.Itoa(count),
+				"refresh_token": "barfoo",
+				"expires_in":    3,
+			})
+		}
 		count = count + 1
 	})
 	r.NotFound(func() string { return "" })

--- a/client.go
+++ b/client.go
@@ -30,6 +30,7 @@ type Config struct {
 	HttpClient        *http.Client
 	SkipSslValidation bool
 	TokenSource       oauth2.TokenSource
+	Endpoint          *Endpoint
 }
 
 type Endpoint struct {
@@ -104,15 +105,7 @@ func NewClient(config *Config) (*Client, error) {
 			return nil
 		}
 	} else {
-		ctx := oauth2.NoContext
-		if config.SkipSslValidation == false {
-			ctx = context.WithValue(ctx, oauth2.HTTPClient, defConfig.HttpClient)
-		} else {
-			tr := &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			}
-			ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: tr})
-		}
+		ctx := getContext(config)
 
 		endpoint, err := getUAAEndpoint(config.BOSHAddress, oauth2.NewClient(ctx, nil))
 
@@ -120,16 +113,10 @@ func NewClient(config *Config) (*Client, error) {
 			return nil, fmt.Errorf("Could not get api /info: %v", err)
 		}
 
-		authConfig := &oauth2.Config{
-			ClientID: "bosh_cli",
-			Scopes:   []string{""},
-			Endpoint: oauth2.Endpoint{
-				AuthURL:  endpoint.URL + "/oauth/authorize",
-				TokenURL: endpoint.URL + "/oauth/token",
-			},
-		}
+		config.Endpoint = endpoint
 
-		token, err := authConfig.PasswordCredentialsToken(ctx, config.Username, config.Password)
+		authConfig, token, err := getToken(ctx, config)
+
 		if err != nil {
 			return nil, fmt.Errorf("Error getting token: %v", err)
 		}
@@ -217,6 +204,12 @@ func (c *Client) DoRequest(r *request) (*http.Response, error) {
 	req.SetBasicAuth(c.config.Username, c.config.Password)
 	req.Header.Add("User-Agent", "gogo-bosh")
 	resp, err := c.config.HttpClient.Do(req)
+	if err != nil {
+		if strings.Contains(err.Error(), "oauth2: cannot fetch token") {
+			c.refreshClient()
+			resp, err = c.config.HttpClient.Do(req)
+		}
+	}
 	return resp, err
 }
 
@@ -250,6 +243,47 @@ func (c *Client) GetInfo() (info Info, err error) {
 	return
 }
 
+func (c *Client) refreshClient() error {
+	config := c.config
+	ctx := getContext(&config)
+
+	authConfig, token, err := getToken(ctx, &config)
+	if err != nil {
+		return fmt.Errorf("Error getting token: %v", err)
+	}
+
+	config.TokenSource = authConfig.TokenSource(ctx, token)
+	config.HttpClient = oauth2.NewClient(ctx, config.TokenSource)
+
+	return nil
+}
+
+func getToken(ctx context.Context, config *Config) (*oauth2.Config, *oauth2.Token, error) {
+	authConfig := &oauth2.Config{
+		ClientID: "bosh_cli",
+		Scopes:   []string{""},
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  config.Endpoint.URL + "/oauth/authorize",
+			TokenURL: config.Endpoint.URL + "/oauth/token",
+		},
+	}
+	token, err := authConfig.PasswordCredentialsToken(ctx, config.Username, config.Password)
+	return authConfig, token, err
+}
+
+func getContext(config *Config) context.Context {
+	ctx := oauth2.NoContext
+	if config.SkipSslValidation == false {
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, config.HttpClient)
+	} else {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: tr})
+	}
+	return ctx
+}
+
 // toHTTP converts the request to an HTTP request
 func (r *request) toHTTP() (*http.Request, error) {
 
@@ -266,6 +300,7 @@ func (r *request) toHTTP() (*http.Request, error) {
 	return http.NewRequest(r.method, r.url, r.body)
 }
 
+// GetToken - returns the current token bearer
 func (c *Client) GetToken() (string, error) {
 	token, err := c.config.TokenSource.Token()
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Client", func() {
 					Expect(err).Should(BeNil())
 					token, err = client.GetToken()
 					Expect(err).Should(BeNil())
-					Consistently(token).Should(Equal("bearer foobar7"))
+					Consistently(token).Should(Equal("bearer foobar10"))
 				})
 			})
 


### PR DESCRIPTION
### What is it?

Some UAA implementations set an expiry time on refresh tokens, new access tokens can currently be requested the entire time that refresh token is valid. If however the refresh token is invalid/ expired then the client will be stuck with a stale token and will return an error on any attempt to call the API.

This PR proposes to resolve this issue by updating the gogobosh client with a brand new oauth process as part of DoRequest if an oauth error on fetching the token had occurred.

Best efforts have been made to ensure that the new code path is tested as part of client_test.go
