### PR TITLE
Always return consistent errors

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -245,7 +245,7 @@ var _ = Describe("Api", func() {
 				Expect(vms[0].Processes[0].Mem.Percent).Should(Equal(16.5))
 				Expect(vms[0].Processes[0].State).Should(Equal("running"))
 				Expect(vms[0].Processes[0].Uptime.Secs).Should(Equal(11794845))
-				Expect(vms[0].ResurectionPaused).Should(BeFalse())
+				Expect(vms[0].ResurrectionPaused).Should(BeFalse())
 				Expect(vms[0].AZ).Should(Equal("z1"))
 				Expect(vms[0].ID).Should(Equal("4a9278c8-e93a-4d6a-b22c-13560208da9e"))
 				Expect(vms[0].Bootstrap).Should(BeTrue())

--- a/client_test.go
+++ b/client_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Client", func() {
 					Expect(err).Should(BeNil())
 					Expect(token).Should(Equal("bearer foobar2"))
 					token, err = client.GetToken()
-					Expect(err).Should(MatchError("Error getting bearer token: oauth2: cannot fetch token: 401 Unauthorized\nResponse: {\"error\":\"invalid_token\",\"error_description\":\"Invalid refresh token (expired)\"}"))
+					Expect(err).Should(MatchError("error getting bearer token: oauth2: cannot fetch token: 401 Unauthorized\nResponse: {\"error\":\"invalid_token\",\"error_description\":\"Invalid refresh token (expired)\"}"))
 					Expect(token).Should(Equal(""))
 				})
 			})

--- a/gogobosh_suite_test.go
+++ b/gogobosh_suite_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestBoshclient(t *testing.T) {
+func TestBoshClient(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Boshclient Suite")
+	RunSpecs(t, "BoshClient Suite")
 }

--- a/models.go
+++ b/models.go
@@ -65,26 +65,26 @@ type Manifest struct {
 
 // VM struct
 type VM struct {
-	VMCID             string    `json:"vm_cid"`
-	IPs               []string  `json:"ips"`
-	DNS               []string  `json:"dns"`
-	AgentID           string    `json:"agent_id"`
-	JobName           string    `json:"job_name"`
-	Index             int       `json:"index"`
-	JobState          string    `json:"job_state"`
-	State             string    `json:"state"`
-	ResourcePool      string    `json:"resource_pool"`
-	VMType            string    `json:"vm_type"`
-	Vitals            Vitals    `json:"vitals"`
-	Processes         []Process `json:"processes"`
-	ResurectionPaused bool      `json:"resurrection_paused"`
-	AZ                string    `json:"az"`
-	ID                string    `json:"id"`
-	Bootstrap         bool      `json:"bootstrap"`
-	Ignore            bool      `json:"ignore"`
+	VMCID              string    `json:"vm_cid"`
+	IPs                []string  `json:"ips"`
+	DNS                []string  `json:"dns"`
+	AgentID            string    `json:"agent_id"`
+	JobName            string    `json:"job_name"`
+	Index              int       `json:"index"`
+	JobState           string    `json:"job_state"`
+	State              string    `json:"state"`
+	ResourcePool       string    `json:"resource_pool"`
+	VMType             string    `json:"vm_type"`
+	Vitals             Vitals    `json:"vitals"`
+	Processes          []Process `json:"processes"`
+	ResurrectionPaused bool      `json:"resurrection_paused"`
+	AZ                 string    `json:"az"`
+	ID                 string    `json:"id"`
+	Bootstrap          bool      `json:"bootstrap"`
+	Ignore             bool      `json:"ignore"`
 }
 
-// VM Vitals struct
+// Vitals for a VM
 type Vitals struct {
 	Disk Disk     `json:"disk"`
 	Load []string `json:"load"`
@@ -119,7 +119,7 @@ type Memory struct {
 	KB      string `json:"KB"`
 }
 
-// VM Process struct
+// Process running on a VM
 type Process struct {
 	Name   string        `json:"name"`
 	State  string        `json:"state"`


### PR DESCRIPTION
- Some errors were being swallowed or not wrapped using newer go semnatics.
- Fixed a few other warnings aroung ignored errors in defer statements.